### PR TITLE
Add support for STM32L100C Discovery board

### DIFF
--- a/common/stm32l100c-disco.mk
+++ b/common/stm32l100c-disco.mk
@@ -1,0 +1,3 @@
+DEVICE=stm32l100rct6
+
+include common/opencm3.mk


### PR DESCRIPTION
Hi, this is what I used to make it work on the STM32L100C Dicovery board with a STM32L100RCT6 core.

`GPIO_OSPEED_100MHZ` is not defined in [libopencm3/stm32/l1/gpio.h](https://github.com/libopencm3/libopencm3/blob/master/include/libopencm3/stm32/l1/gpio.h), so I switched that to `GPIO_OSPEED_40MHZ`.

Currently it uses the PLL clock at 16 MHz, which is really the `CLOCK_BENCHMARK` case. You might want to add a `CLOCK_FAST` if desired and perhaps refactor this a bit to combine code with the `STM32F2` case.